### PR TITLE
Change Pay Gateway exception

### DIFF
--- a/PAYEER.php
+++ b/PAYEER.php
@@ -20,7 +20,7 @@ class Payment_Adapter_PAYEER implements \FOSSBilling\InjectionAwareInterface
         $this->config = $config;
         foreach (['merchant_id', 'secret_key'] as $key) {
             if (!isset($this->config[$key])) {
-                throw new \Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'BTCPay', ':missing' => $key], 4001);
+                throw new \Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'PAYEER', ':missing' => $key], 4001);
             }
         }
     }


### PR DESCRIPTION
Change BTCPay to PAYEER in the gateway exception for the configuration.

Ensure that when checking IPN duplicates, you verify if the status is the same or not.

Suggestions:

1) I'm unsure if the amount should be checked on IPN duplicates; perhaps you could review this.
2) Consider capturing failed transactions and retrying them to ensure success, using the same transaction if it remains unchanged.